### PR TITLE
Do not publish appsettings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ This sample shows you how to use the Microsoft Azure Cosmos DB service to store 
 
 2. Clone this repository using Git for Windows (http://www.git-scm.com/), or download the zip file.
 
-3. From Visual Studio, open the [CosmosWebSample.csproj](./src/CosmosWebSample.csproj).
+3. From Visual Studio, open the [todo.csproj](./src/todo.csproj).
 
 4. In Visual Studio Build menu, select **Build Solution** (or Press F6). 
 
 5. Retrieve the URI and PRIMARY KEY (or SECONDARY KEY) values from the Keys blade of your Azure Cosmos account in the Azure portal. For more information on obtaining endpoint & keys for your Azure Cosmos account refer to [View, copy, and regenerate access keys and passwords](https://docs.microsoft.com/azure/cosmos-db/secure-access-to-data#master-keys)  **if you are going to work with a real Azure Cosmos account**.
     * The default configuration is setup to work with a local Azure Cosmos DB Emulator.
 
-6. In the [appSettings.json](./src/appSettings.json) file, located in the project root, find **Account** and **Key** and replace the placeholder values with the values obtained for your account if you are going to work with a real Azure Cosmos account.
+6. In the [appsettings.json](./src/appsettings.json) file, located in the project root, find **Account** and **Key** and replace the placeholder values with the values obtained for your account if you are going to work with a real Azure Cosmos account.
 
 7. You can now run and debug the application locally by pressing **F5** in Visual Studio.
 
@@ -49,19 +49,19 @@ For additional ways to deploy this web application to Azure, please refer to the
 ## Running this sample from the .NET Core command line
 
 1. Before you can run this sample, you must have the following prerequisites:
-    - [.NET Core SDK 2.1 or higher](https://dotnet.microsoft.com/download)
+    - [.NET Core SDK 3.1 or higher](https://dotnet.microsoft.com/download)
     - An active Azure Cosmos account or the [Azure Cosmos DB Emulator](https://docs.microsoft.com/azure/cosmos-db/local-emulator) - If you don't have an account, refer to the [Create a database account](https://docs.microsoft.com/azure/cosmos-db/create-sql-api-dotnet#create-an-azure-cosmos-db-account) article
 
 2. Clone this repository using your Git command line, or download the zip file.
 
-3. Go to the location of the [CosmosWebSample.csproj](./src/CosmosWebSample.csproj) in your command line prompt.
+3. Go to the location of the [todo.csproj](./src/todo.csproj) in your command line prompt.
 
 4. Run `dotnet build` to restore packages and build the project.
 
 5. Retrieve the URI and PRIMARY KEY (or SECONDARY KEY) values from the Keys blade of your Azure Cosmos account in the Azure portal. For more information on obtaining endpoint & keys for your Azure Cosmos account refer to [View, copy, and regenerate access keys and passwords](https://docs.microsoft.com/azure/cosmos-db/secure-access-to-data#master-keys) **if you are going to work with a real Azure Cosmos account**.
     * The default configuration is setup to work with a local Azure Cosmos DB Emulator.
 
-6. In the [appSettings.json](./src/appSettings.json) file, located in the project root, find **Account** and **Key** and replace the placeholder values with the values obtained for your account if you are going to work with a real Azure Cosmos account.
+6. In the [appsettings.json](./src/appsettings.json) file, located in the project root, find **Account** and **Key** and replace the placeholder values with the values obtained for your account if you are going to work with a real Azure Cosmos account.
 
 7. You can now run and debug the application locally by running `dotnet run` and browsing the Url provided by the .NET Core command line.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,13 @@ This sample shows you how to use the Microsoft Azure Cosmos DB service to store 
 
 4. Once you have selected the App Service, click **Publish**
 
-5. After a short time, Visual Studio will complete the deployment and open a browser with your deployed application. 
+5. After a short time, Visual Studio will complete the deployment.
+
+6. After deployment, go you your Web App in the Azure Portal and make sure to [add the App Settings](https://docs.microsoft.com/azure/app-service/configure-common#configure-app-settings):
+    1. `CosmosDb.Account`: The endpoint for the Azure Cosmos account.
+    1. `CosmosDb.Key`: The key for the Azure Cosmos account.
+    1. `CosmosDb.DatabaseName`: The name of the Azure Cosmos database to use.
+    1. `CosmosDb.ContainerName`: The name of the Azure Cosmos container to use.
 
 For additional ways to deploy this web application to Azure, please refer to the [Deploy ASP.NET Core apps to Azure App Service](https://docs.microsoft.com/aspnet/core/host-and-deploy/azure-apps/?view=aspnetcore-2.2) article which includes information on using Azure Pipelines, CLI, and many more. 
 
@@ -77,7 +83,13 @@ For additional ways to deploy this web application to Azure, please refer to the
 
 5. Select your Azure subscription and whether you want to select an existing Web App or create a new one. Note: If you choose to create a new one, the App Name chosen must be globally unique. 
 
-6. After a short time, Visual Studio Code will complete the deployment and a visual prompt to *Browse Website* should appear.
+6. After a short time, Visual Studio Code will complete the deployment.
+
+7. After deployment, go you your Web App in the Azure Portal and make sure to [add the App Settings](https://docs.microsoft.com/azure/app-service/configure-common#configure-app-settings):
+    1. `CosmosDb.Account`: The endpoint for the Azure Cosmos account.
+    1. `CosmosDb.Key`: The key for the Azure Cosmos account.
+    1. `CosmosDb.DatabaseName`: The name of the Azure Cosmos database to use.
+    1. `CosmosDb.ContainerName`: The name of the Azure Cosmos container to use.
 
 For additional ways to deploy this web application to Azure, please refer to [Deploy to Azure using App Service](https://code.visualstudio.com/tutorials/app-service-extension/getting-started) or [Deploy to Azure using the Azure CLI](https://code.visualstudio.com/tutorials/nodejs-deployment/getting-started).
 

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -63,10 +63,7 @@
             string containerName = configurationSection.GetSection("ContainerName").Value;
             string account = configurationSection.GetSection("Account").Value;
             string key = configurationSection.GetSection("Key").Value;
-            Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder clientBuilder = new Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder(account, key);
-            Microsoft.Azure.Cosmos.CosmosClient client = clientBuilder
-                                .WithConnectionModeDirect()
-                                .Build();
+            Microsoft.Azure.Cosmos.CosmosClient client = new Microsoft.Azure.Cosmos.CosmosClient(account, key);
             CosmosDbService cosmosDbService = new CosmosDbService(client, databaseName, containerName);
             Microsoft.Azure.Cosmos.DatabaseResponse database = await client.CreateDatabaseIfNotExistsAsync(databaseName);
             await database.Database.CreateContainerIfNotExistsAsync(containerName, "/id");

--- a/src/appsettings.Development.json
+++ b/src/appsettings.Development.json
@@ -1,9 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
-    }
-  }
-}

--- a/src/todo.csproj
+++ b/src/todo.csproj
@@ -5,7 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.8.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.10.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Update="appsettings.json">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR changes the configuration to avoid publishing appsettings.json, secrets and configurations should be set through configuration on the service, for example: https://docs.microsoft.com/en-us/azure/app-service/configure-common

Configuration settings after being published can be set through variables named:

`CosmosDb:Account`, `CosmosDb:Key`, `CosmosDb:DatabaseName`, `CosmosDb:ContainerName`.