### PR TITLE
Add Dockerfile to make a kubernetes-deployable image

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,0 +1,17 @@
+# https://hub.docker.com/_/microsoft-dotnet
+FROM mcr.microsoft.com/dotnet/sdk:3.1 AS build
+WORKDIR /source
+
+# copy csproj and restore as distinct layers
+COPY *.csproj .
+RUN dotnet restore
+
+# copy and publish app and libraries
+COPY . .
+RUN dotnet publish -c release -o /app --no-restore
+
+# final stage/image
+FROM mcr.microsoft.com/dotnet/aspnet:3.1
+WORKDIR /app
+COPY --from=build /app .
+ENTRYPOINT ["dotnet", "todo.dll"]


### PR DESCRIPTION
On the Azure Service Operator team we're working on a demo for provisioning CosmosDB using the operator and then deploying this app into a pod in a Kubernetes cluster and configuring it to talk to the SQL database. I used this Dockerfile to create a deployable image for the app. The demo won't require the user to build the image themselves - we'll publish an image to a public registry - but it would be useful to have it alongside the code, because the demo will link to this repo so they can see how to use the CosmosDB client libraries for their own applications.

